### PR TITLE
Add Spanish localization files

### DIFF
--- a/Localization-dialog-es.lua
+++ b/Localization-dialog-es.lua
@@ -1,0 +1,305 @@
+------------------------------------------------------------------------------------------------------
+-- Necrosis LdC
+--
+-- Crateur initial (US) : Infernal (http://www.revolvus.com/games/interface/necrosis/)
+-- Implmentation de base (FR) : Tilienna Thorondor
+-- Reprise du projet : Lomig & Nyx des Larmes de Cenarius, Kael'Thas
+-- 
+-- Skins et voix Franaises : Eliah, Ner'zhul
+-- Version Allemande par Arne Meier et Halisstra, Lothar
+-- Remerciements spciaux pour Sadyre (JoL)
+-- Version 06.05.2006-1
+------------------------------------------------------------------------------------------------------
+
+
+------------------------------------------------
+-- SPANISH VERSION TEXTS --
+------------------------------------------------
+
+function Necrosis_Localization_Dialog_Es()
+
+	function NecrosisLocalization()
+		Necrosis_Localization_Speech_En();
+	end
+
+	NECROSIS_COOLDOWN = {
+		["Spellstone"] = "Spellstone Cooldown",
+		["Healthstone"] = "Healthstone Cooldown"
+	};
+
+	NecrosisTooltipData = {
+		["Main"] = {
+			Label = "|c00FFFFFFNecrosis|r",
+			Stone = {
+				[true] = "Yes";
+				[false] = "No";
+			},
+			Hellspawn = {
+				[true] = "On";
+				[false] = "Off";
+			},
+			["Soulshard"] = "Soul Shard(s) : ",
+			["InfernalStone"] = "Infernal Stone(s) : ",
+			["DemoniacStone"] = "Demonic Figurine(s) ",
+			["Soulstone"] = "\nSoulstone : ",
+			["Healthstone"] = "Healthstone : ",
+			["Spellstone"] = "Spellstone : ",
+			["Firestone"] = "Firestone : ",
+			["CurrentDemon"] = "Demon : ",
+			["EnslavedDemon"] = "Demon : Enslaved",
+			["NoCurrentDemon"] = "Demon : None",
+		},
+		["Soulstone"] = {
+			Label = "|c00FF99FFSoulstone|r",
+			Text = {"Create","Use","Used","Waiting"}
+		},
+		["Healthstone"] = {
+			Label = "|c0066FF33Healthstone|r",
+			Text = {"Create","Use"}
+		},
+		["Spellstone"] = {
+			Label = "|c0099CCFFSpellstone|r",
+			Text = {"Create","In Inventory","Held in hand"}
+		},
+		["Firestone"] = {
+			Label = "|c00FF4444Firestone|r",
+			Text = {"Create","In Inventory","Held in hand"}
+		},
+		["SpellTimer"] = {
+			Label = "|c00FFFFFFSpell Durations|r",
+			Text = "Active Spells on the target",
+			Right = "Right Click for Hearthstone to "
+		},
+		["ShadowTrance"] = {
+			Label = "|c00FFFFFFTrance de las Sombras|r"
+		},
+		["Domination"] = {
+			Label = "|c00FFFFFFDominio vil|r"
+		},
+		["Enslave"] = {
+			Label = "|c00FFFFFFEsclavizar|r"
+		},
+		["Armor"] = {
+			Label = "|c00FFFFFFArmadura demoníaca|r"
+		},
+		["Invisible"] = {
+			Label = "|c00FFFFFFDetectar invisibilidad|r"
+		},
+		["Aqua"] = {
+			Label = "|c00FFFFFFRespiración inagotable|r"
+		},
+		["Kilrogg"] = {
+			Label = "|c00FFFFFFOjo de Kilrogg|r"
+		},
+		["Banish"] = {
+			Label = "|c00FFFFFFDesterrar|r"
+		},
+		["TP"] = {
+			Label = "|c00FFFFFFRitual de invocación|r"
+		},
+		["SoulLink"] = {
+			Label = "|c00FFFFFFEnlace de alma|r"
+		},
+		["ShadowProtection"] = {
+			Label = "|c00FFFFFFResguardo de las Sombras|r"
+		},
+		["Imp"] = {
+			Label = "|c00FFFFFFDiablillo|r"
+		},
+		["Void"] = {
+			Label = "|c00FFFFFFAbisario|r"
+		},
+		["Succubus"] = {
+			Label = "|c00FFFFFFSúccubo|r"
+		},
+		["Fel"] = {
+			Label = "|c00FFFFFFManáfago|r"
+		},
+		["Infernal"] = {
+			Label = "|c00FFFFFFInfernal|r"
+		},
+		["Doomguard"] = {
+			Label = "|c00FFFFFFGuardia apocalíptico|r"
+		},
+		["Sacrifice"] = {
+			Label = "|c00FFFFFFSacrificio demoníaco|r"
+		},
+		["Amplify"] = {
+			Label = "|c00FFFFFFAmplificar maldición|r"
+		},
+		["Weakness"] = {
+			Label = "|c00FFFFFFMaldición de debilidad|r"
+		},
+		["Agony"] = {
+			Label = "|c00FFFFFFMaldición de agonía|r"
+		},
+		["Reckless"] = {
+			Label = "|c00FFFFFFMaldición de temeridad|r"
+		},
+		["Tongues"] = {
+			Label = "|c00FFFFFFMaldición de las Lenguas|r"
+		},
+		["Exhaust"] = {
+			Label = "|c00FFFFFFMaldición de extenuación|r"
+		},
+		["Elements"] = {
+			Label = "|c00FFFFFFMaldición de los Elementos|r"
+		},
+		["Shadow"] = {
+			Label = "|c00FFFFFFMaldición de la Sombra|r"
+		},
+		["Doom"] = {
+			Label = "|c00FFFFFFMaldición de fatalidad|r"
+		},
+		["Mount"] = {
+			Label = "|c00FFFFFFCorcel|r"
+		},
+		["Buff"] = {
+			Label = "|c00FFFFFFSpell Menu|r\nRight click to keep the menu open"
+		},
+		["Pet"] = {
+			Label = "|c00FFFFFFDemon Menu|r\nRight click to keep the menu open"
+		},
+		["Curse"] = {
+			Label = "|c00FFFFFFCurse Menu|r\nRight click to keep the menu open"
+		},
+		["Radar"] = {
+			Label = "|c00FFFFFFSense Demons|r"
+		},
+		["AmplifyCooldown"] = "Right click to amplify curse",
+		["DominationCooldown"] = "Right click for fast summon",
+		["LastSpell"] = "Middle click to cast ",
+	};
+
+
+	NECROSIS_SOUND = {
+		["Fear"] = "Interface\\AddOns\\Necrosis\\sounds\\Fear-En.mp3",
+		["SoulstoneEnd"] = "Interface\\AddOns\\Necrosis\\sounds\\SoulstoneEnd-En.mp3",
+		["EnslaveEnd"] = "Interface\\AddOns\\Necrosis\\sounds\\EnslaveDemonEnd-En.mp3",
+		["ShadowTrance"] = "Interface\\AddOns\\Necrosis\\sounds\\ShadowTrance-En.mp3"
+	};
+
+
+	NECROSIS_NIGHTFALL_TEXT = {
+		["NoBoltSpell"] = "You do not seem to have any Shadow Bolt Spell.",
+		["Message"] = "<white>S<lightPurple1>h<lightPurple2>a<purple>d<darkPurple1>o<darkPurple2>w T<darkPurple1>r<purple>a<lightPurple2>n<lightPurple1>c<white>e"
+	};
+
+
+	NECROSIS_MESSAGE = {
+		["Error"] = {
+			["InfernalStoneNotPresent"] = "You need an Infernal Stone to do that !",
+			["SoulShardNotPresent"] = "You need a Soul shard to do that !",
+			["DemoniacStoneNotPresent"] = "You need a Demoniac Figurine to do that !",
+			["NoRiding"] = "You do not have any Steed to ride !",
+			["NoFireStoneSpell"] = "You do not have any Firestone creation spell",
+			["NoSpellStoneSpell"] = "You do not have any Spellstone creation spell",
+			["NoHealthStoneSpell"] = "You do not have any Healthstone creation spell",
+			["NoSoulStoneSpell"] = "You do not have any Soulstone creation spell",
+			["FullHealth"] = "You cannot use your Healthstone as you are not hurt",
+			["BagAlreadySelect"] = "Error : This bag is already selected.",
+			["WrongBag"] = "Error : The number must be between 0 and 4.",
+			["BagIsNumber"] = "Error : Please type a number.",
+			["NoHearthStone"] = "Error : You do not have a Hearthstone in your inventory"
+		},
+		["Bag"] = {
+			["FullPrefix"] = "Your ",
+			["FullSuffix"] = " is full !",
+			["FullDestroySuffix"] = " is full; Next shards will be destroyed !",
+			["SelectedPrefix"] = "You have chosen your ",
+			["SelectedSuffix"] = " to keep your shards."
+		},
+		["Interface"] = {
+			["Welcome"] = "<white>/necro to show the setting menu !",
+			["TooltipOn"] = "Tooltips turned on" ,
+			["TooltipOff"] = "Tooltips turned off",
+			["MessageOn"] = "Chat messaging turned on",
+			["MessageOff"] = "Chat messaging turned off",
+			["MessagePosition"] = "<- System messages by Necrosis will appear here ->",
+			["DefaultConfig"] = "<lightYellow>Default configuration loaded.",
+			["UserConfig"] = "<lightYellow>Configuration loaded."
+		},
+		["Help"] = {
+			"/necro recall -- Center Necrosis and all buttons in the middle of the screen",
+			"/necro sm -- Replace Soulstoning and summoning messages with a short raid-ready version"
+		},
+		["EquipMessage"] = "Equip ",
+		["SwitchMessage"] = " instead of ",
+		["Information"] = {
+			["FearProtect"] = "Your target has got a fear protection !!!!",
+			["EnslaveBreak"] = "Your demon broke his chains...",
+			["SoulstoneEnd"] = "<lightYellow>Your Soulstone has faded."
+		}
+	};
+
+
+	-- Gestion XML - Menu de configuration
+
+	NECROSIS_COLOR_TOOLTIP = {
+		["Purple"] = "Purple",
+		["Blue"] = "Blue",
+		["Pink"] = "Pink",
+		["Orange"] = "Orange",
+		["Turquoise"] = "Turquoise",
+		["X"] = "X"
+	};
+	
+	NECROSIS_CONFIGURATION = {
+		["Menu1"] = "Shard Settings",
+		["Menu2"] = "Message Settings",
+		["Menu3"] = "Button Settings",
+		["Menu4"] = "Timer Settings",
+		["Menu5"] = "Graphical Settings",
+		["MainRotation"] = "Necrosis Angle Selection",
+		["ShardMenu"] = "|CFFB700B7I|CFFFF00FFn|CFFFF50FFv|CFFFF99FFe|CFFFFC4FFn|CFFFF99FFt|CFFFF50FFo|CFFFF00FFr|CFFB700B7y :",
+		["ShardMenu2"] = "|CFFB700B7S|CFFFF00FFh|CFFFF50FFa|CFFFF99FFr|CFFFFC4FFd C|CFFFF99FFo|CFFFF50FFu|CFFFF00FFn|CFFB700B7t :",
+		["ShardMove"] = "Put shards in the selected bag.",
+		["ShardDestroy"] = "Destroy all new shards if the bag is full.",
+		["SpellMenu1"] = "|CFFB700B7S|CFFFF00FFp|CFFFF50FFe|CFFFF99FFl|CFFFFC4FFls :",
+		["SpellMenu2"] = "|CFFB700B7P|CFFFF00FFl|CFFFF50FFa|CFFFF99FFy|CFFFFC4FFe|CFFFF99FFr :",
+		["TimerMenu"] = "|CFFB700B7G|CFFFF00FFr|CFFFF50FFa|CFFFF99FFp|CFFFFC4FFh|CFFFF99FFi|CFFFF50FFc|CFFFF00FFa|CFFB700B7l T|CFFFF00FFi|CFFFF50FFm|CFFFF99FFe|CFFFFC4FFrs :",
+		["TimerColor"] = "Show white instead of yellow timer texts",
+		["TimerDirection"] = "Timers grow upwards",
+		["TranseWarning"] = "Alert me when I enter a Trance State",
+		["SpellTime"] = "Turn on the spell durations indicator",
+		["AntiFearWarning"] = "Warn me when my target cannot be feared.",
+		["GraphicalTimer"] = "Show graphical instead text timers",	
+		["TranceButtonView"] = "Let me see hidden buttons to drag them.",
+		["ButtonLock"] = "Lock the buttons around the Necrosis Sphere.",
+		["MainLock"] = "Lock buttons and the Necrosis Sphere.",
+		["BagSelect"] = "Selection of Soul Shard Container",
+		["BuffMenu"] = "Put buff menu on the left",
+		["PetMenu"] = "Put pet menu on the left",
+		["CurseMenu"] = "Put curse menu on the left",
+		["STimerLeft"] = "Show timers on the left side of the button",
+		["ShowCount"] = "Show the Shard count in Necrosis",
+		["CountType"] = "Stone type counted",
+		["Circle"] = "Event shown by the graphical sphere",
+		["Sound"] = "Activate sounds",
+		["ShowMessage"] = "Activate random speeches",
+		["ShowDemonSummon"] = "Activate random speeches (demon)",
+		["ShowSteedSummon"] = "Activate random speeches (steed)",
+		["ChatType"] = "Declare Necrosis messages as system messages",
+		["NecrosisSize"] = "Size of the Necrosis button",
+		["BanishSize"] = "Size of the Banish button",
+		["TranseSize"] = "Size of Transe and Anti-fear buttons",
+		["Skin"] = "Skin of the Necrosis Sphere",
+		["Show"] = {
+			["Firestone"] = "Show Firestone button",
+			["Spellstone"] = "Show Spellstone button",
+			["Healthstone"] = "Show Healthstone button",
+			["Soulstone"] = "Show Soulstone button",
+			["Steed"] = "Show Steed button",
+			["Buff"] = "Show Spell menu button",
+			["Curse"] = "Show Curse menu button",
+			["Demon"] = "Show Demon menu button",
+			["Tooltips"] = "Show tooltips"
+		},
+		["Count"] = {
+			["Shard"] = "Soulshards",
+			["Inferno"] = "Demon summoning stones",
+			["Rez"] = "Resurrection Timer"
+		}
+	};
+
+end

--- a/Localization-functions-es.lua
+++ b/Localization-functions-es.lua
@@ -1,0 +1,210 @@
+------------------------------------------------------------------------------------------------------
+-- Necrosis LdC
+--
+-- Crateur initial (US) : Infernal (http://www.revolvus.com/games/interface/necrosis/)
+-- Implmentation de base (FR) : Tilienna Thorondor
+-- Reprise du projet : Lomig & Nyx des Larmes de Cenarius, Kael'Thas
+--
+-- Skins et voix Franaises : Eliah, Ner'zhul
+-- Version Allemande par Arne Meier et Halisstra, Lothar
+-- Remerciements spciaux pour Sadyre (JoL)
+-- Version 06.05.2006-1
+------------------------------------------------------------------------------------------------------
+
+
+
+------------------------------------------------
+-- SPANISH VERSION FUNCTIONS --
+------------------------------------------------
+
+if ( GetLocale() == "esES" ) then
+
+NECROSIS_UNIT_WARLOCK = "Brujo";
+
+NECROSIS_ANTI_FEAR_SPELL = {
+	-- Buffs giving temporary immunity to fear effects
+	["Buff"] = {
+		"Resguardo contra el miedo",			-- Dwarf priest racial trait
+		"Voluntad de los Renegados",		-- Forsaken racial trait
+		"Intrépido",			-- Trinket
+		"Ira rabiosa",		-- Warrior Fury talent
+		"Temeridad",			-- Warrior Fury talent
+		"Deseo de muerte",			-- Warrior Fury talent
+		"Ira bestial",		-- Hunter Beast Mastery talent (pet only)
+		"Bloque de hielo",			-- Mage Ice talent
+		"Protección divina",		-- Paladin Holy buff
+		"Escudo divino",		-- Paladin Holy buff
+		"Tótem de tremor",			-- Shaman totem
+		"Suprimir magia"			-- Majordomo (NPC) spell
+		--  "Grounding Totem" is not considerated, as it can remove other spell than fear, and only one each 10 sec.		
+	},
+
+	-- Debuffs and curses giving temporary immunity to fear effects
+	["Debuff"] = {
+		"Curse of Temeridad"		-- Warlock curse
+	}
+};
+
+-- Creature type absolutly immune to fear effects
+NECROSIS_ANTI_FEAR_UNIT = {
+	"No-muerto"
+};
+
+-- Word to search for spell immunity. First (.+) replace the spell's name, 2nd (.+) replace the creature's name
+NECROSIS_ANTI_FEAR_SRCH = "Tu (.+) ha fallado. (.+) es inmune."
+
+NECROSIS_SPELL_TABLE = {
+	[1] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Invocar corcel vil",		Length = 0,	Type = 0},
+	[2] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil, 
+		Name = "Invocar corcel nefasto",		Length = 0,	Type = 0},
+	[3] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Invocar diablillo",			Length = 0,	Type = 0},
+	[4] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Invocar abisario",		Length = 0,	Type = 0},
+	[5] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Invocar súcubo",		Length = 0,	Type = 0},
+	[6] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Invocar manáfago",		Length = 0,	Type = 0},
+	[7] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Descarga de las Sombras",			Length = 0,	Type = 0},
+	[8] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Infernal",			Length = 3600,	Type = 3},
+	[9] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Desterrar",			Length = 30,	Type = 2},
+	[10] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Esclavizar demonio",			Length = 30000,	Type = 2},
+	[11] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Resurrección de piedra de alma",	Length = 1800,	Type = 1},
+	[12] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Inmolar",			Length = 15,	Type = 5},
+	[13] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Fear",				Length = 15,	Type = 5},
+	[14] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Corrupción",			Length = 17,	Type = 5},
+	[15] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Dominio vil",		Length = 300,	Type = 3},
+	[16] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Maldición de fatalidad",			Length = 60,	Type = 3},
+	[17] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Sacrificio",			Length = 30,	Type = 3},
+	[18] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Fuego de alma",			Length = 60,	Type = 3},
+	[19] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Espiral mortal",			Length = 120,	Type = 3},
+	[20] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Quemadura de las Sombras",			Length = 15,	Type = 3},
+	[21] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Conflagrar",			Length = 10,	Type = 3},
+	[22] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Maldición de agonía",		Length = 24,	Type = 4},
+	[23] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Maldición de debilidad",		Length = 120,	Type = 4},
+	[24] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Curse of Temeridad",		Length = 120,	Type = 4},
+	[25] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Maldición de las Lenguas",		Length = 30,	Type = 4},
+	[26] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Maldición de los Elementos",		Length = 300,	Type = 4},
+	[27] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Maldición de la Sombra",		Length = 300,	Type = 4},
+	[28] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Sifón de vida",			Length = 30,	Type = 5},
+	[29] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Aullido de terror",		Length = 40,	Type = 3},
+	[30] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Ritual de fatalidad",		Length = 3600,	Type = 0},
+	[31] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Armadura demoníaca",			Length = 0,	Type = 0},
+	[32] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Respiración inagotable",		Length = 0,	Type = 0},
+	[33] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Invisibilidad",			Length = 0,	Type = 0},
+	[34] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Ojo de Kilrogg",		Length = 0,	Type = 0},
+	[35] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Esclavizar demonio",			Length = 0,	Type = 0},
+	[36] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Piel de demonio",			Length = 0,	Type = 0},
+	[37] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Ritual de invocación",		Length = 0,	Type = 0},
+	[38] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Enlace de alma",			Length = 0,	Type = 0},
+	[39] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Detectar demonios",			Length = 0,	Type = 0},
+	[40] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Maldición de extenuación",		Length = 12,	Type = 4},
+	[41] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Transfusión de vida",			Length = 0,	Type = 0},
+	[42] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Amplificar maldición",			Length = 180,	Type = 3},
+	[43] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Resguardo de las Sombras",			Length = 30,	Type = 3},
+	[44] = {ID = nil, Rank = nil, CastTime = nil, Mana = nil,
+		Name = "Demonic Sacrificio",		Length = 0,	Type = 0},
+
+};
+-- Type 0 = Pas de Timer
+-- Type 1 = Timer permanent principal
+-- Type 2 = Timer permanent
+-- Type 3 = Timer de cooldown
+-- Type 4 = Timer de maldiction
+-- Type 5 = Timer de combat
+
+NECROSIS_ITEM = {
+	["Soulshard"] = "Fragmento de alma",
+	["Piedra de alma"] = "Soulstone",
+	["Piedra de salud"] = "Healthstone",
+	["Piedra de hechizo"] = "Spellstone",
+	["Piedra de fuego"] = "Firestone",
+	["Offhand"] = "Sostenido en mano izquierda",
+	["Twohand"] = "Dos manos",
+	["InfernalStone"] = "Piedra infernal",
+	["DemoniacStone"] = "Figurilla demoníaca",
+	["Piedra de hogar"] = "Hearthstone",
+	["SoulPouch"] = {"Faltriquera de almas", "Bolsa de tela vil", "Bolsa de tela vil del Núcleo"}	
+};
+
+
+NECROSIS_STONE_RANK = {
+	[1] = " (menor)",	-- Rank Minor
+	[2] = " (inferior)",	-- Rank Lesser
+	[3] = "",		-- Rank Intermediate, no name
+	[4] = " (superior)",	-- Rank Greater
+	[5] = " (sublime)"	-- Rank Major
+};
+
+NECROSIS_NIGHTFALL = {
+	["BoltName"] = "Descarga",
+	["ShadowTrance"] = "Trance de las Sombras"
+};
+
+NECROSIS_CREATE = {
+	[1] = "Create Piedra de alma",
+	[2] = "Create Piedra de salud",
+	[3] = "Create Piedra de hechizo",
+	[4] = "Create Piedra de fuego"
+};
+
+NECROSIS_PET_LOCAL_NAME = {
+	[1] = "Diablillo",
+	[2] = "Abisario",
+	[3] = "Súcubo",
+	[4] = "Manáfago",
+	[5] = "Infernal",
+	[6] = "Guardia apocalíptico"
+};
+
+NECROSIS_TRANSLATION = {
+	["Cooldown"] = "Cooldown",
+	["Hearth"] = "Piedra de hogar",
+	["Rank"] = "Rank",
+	["Invisible"] = "Detectar invisibilidad",
+	["LesserInvisible"] = "Detectar invisibilidad inferior",
+	["GreaterInvisible"] = "Detectar invisibilidad superior",
+	["SoulLinkGain"] = "Ganas Enlace de alma.",
+	["SacrificeGain"] = "Ganas Sacrificio.",
+	["SummoningRitual"] = "Ritual de invocación"
+};
+
+end


### PR DESCRIPTION
## Summary
- add `Localization-functions-es.lua` with Spanish spell names
- add `Localization-dialog-es.lua` with translated spell labels

## Testing
- `luac` command not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_688182d77004832294995e6cfabad19d